### PR TITLE
fix: revert breaking change on `navigationTo`

### DIFF
--- a/Composer/packages/client/src/shell/useShell.ts
+++ b/Composer/packages/client/src/shell/useShell.ts
@@ -21,13 +21,13 @@ import {
   luFilesState,
   qnaFilesState,
   dispatcherState,
+  breadcrumbState,
   designPageLocationState,
   focusPathState,
   userSettingsState,
   clipboardActionsState,
 } from '../recoilModel';
 import { validatedDialogsSelector } from '../recoilModel/selectors/validatedDialogs';
-import { BreadcrumbItem } from '../recoilModel/types';
 
 import { useLgApi } from './lgApi';
 import { useLuApi } from './luApi';
@@ -51,6 +51,7 @@ export function useShell(source: EventSource): Shell {
   const skills = useRecoilValue(skillsState);
   const schemas = useRecoilValue(schemasState);
   const designPageLocation = useRecoilValue(designPageLocationState);
+  const breadcrumb = useRecoilValue(breadcrumbState);
   const focusPath = useRecoilValue(focusPathState);
   const userSettings = useRecoilValue(userSettingsState);
   const clipboardActions = useRecoilValue(clipboardActionsState);
@@ -104,7 +105,7 @@ export function useShell(source: EventSource): Shell {
     updateDialog({ id, content: newDialog.content });
   }
 
-  function navigationTo(path, breadcrumb: BreadcrumbItem[] = []) {
+  function navigationTo(path) {
     navTo(path, breadcrumb);
   }
 


### PR DESCRIPTION
## Description

`navigationTo` should consume Recoild value directly. Otherwise, the breadcrumb can be a string like `triggers[0].actions[0]`

## Task Item

Please include a link to the related issue. [Ex. `Closes #<issue #>`](https://help.github.com/en/articles/closing-issues-using-keywords)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which improve code quality, clean up, add tests, etc)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Doc update (document update)

## Checklist

- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have functionally tested my change

## Screenshots

Please include screenshots or gifs if your PR include UX changes.
